### PR TITLE
Add a guard condition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,25 +13,27 @@ export default function Sitemap(props) {
 		
 		let xml = builder.create("urlset", {encoding: "utf-8"}).att("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9");
 		paths.forEach(function (path) {
-			const slugs = path.props.slugs || [{}];
-			slugs.forEach(slug => {
-				let uri = path.props.path;
-				Object.keys(slug).forEach(key => {
-					const value = slug[key];
-					let midStringRegex = new RegExp(`/:${key}/`, "g");
-					let endStringRegex = new RegExp(`/:${key}$`);
-					if (uri.match(midStringRegex))
-						uri = uri.replace(midStringRegex, `/${value}/`);
-					else
-						uri = uri.replace(endStringRegex, `/${value}`);
+			if (path) {
+				const slugs = path.props.slugs || [{}];
+				slugs.forEach(slug => {
+					let uri = path.props.path;
+					Object.keys(slug).forEach(key => {
+						const value = slug[key];
+						let midStringRegex = new RegExp(`/:${key}/`, "g");
+						let endStringRegex = new RegExp(`/:${key}$`);
+						if (uri.match(midStringRegex))
+							uri = uri.replace(midStringRegex, `/${value}/`);
+						else
+							uri = uri.replace(endStringRegex, `/${value}`);
+					});
+					if (path.props.sitemapIndex) {
+						var item = xml.ele("url");
+						item.ele("loc", hostname + uri);
+						item.ele("priority", path.props.priority || 0);
+						item.ele("changefreq", path.props.changefreq || "never");
+					}
 				});
-				if (path.props.sitemapIndex) {
-					var item = xml.ele("url");
-					item.ele("loc", hostname + uri);
-					item.ele("priority", path.props.priority || 0);
-					item.ele("changefreq", path.props.changefreq || "never");
-				}
-			});
+			}
 		});
 		return xml.end({ pretty: props.prettify });
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default function Sitemap(props) {
 	const Routes = props.routes;
 
 	const sitemap = () => {
-		let paths = Routes(props).props.children;
+		let paths = Routes(props)?.props?.children;
 		if (!paths || !Array.isArray(paths)) return null;
 		
 		let xml = builder.create("urlset", {encoding: "utf-8"}).att("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9");

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ export default function Sitemap(props) {
 
 	const sitemap = () => {
 		let paths = Routes(props).props.children;
+		if (!paths || !Array.isArray(paths)) return null;
+		
 		let xml = builder.create("urlset", {encoding: "utf-8"}).att("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9");
 		paths.forEach(function (path) {
 			const slugs = path.props.slugs || [{}];


### PR DESCRIPTION
If there are no routes initially, return null, instead of crashing with the error `paths.forEach is not a function`